### PR TITLE
Fix saveAccounts() method in ServerSolution.java

### DIFF
--- a/src/banking/primitive/core/ServerSolution.java
+++ b/src/banking/primitive/core/ServerSolution.java
@@ -110,8 +110,8 @@ class ServerSolution implements AccountServer {
 			out = new ObjectOutputStream(new FileOutputStream(fileName));
 
 			out.writeObject(Integer.valueOf(accountMap.size()));
-			for (int i=0; i < accountMap.size(); i++) {
-				out.writeObject(accountMap.get(i));
+			for (Account acc : accountMap.values()) {
+				out.writeObject(acc);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION
Account objects in accountMap are now being correctly written
to accounts.ser.