### PR TITLE
Convert integer argument to String object

### DIFF
--- a/src/banking/primitive/core/ServerSolution.java
+++ b/src/banking/primitive/core/ServerSolution.java
@@ -111,7 +111,7 @@ class ServerSolution implements AccountServer {
 
 			out.writeObject(Integer.valueOf(accountMap.size()));
 			for (int i=0; i < accountMap.size(); i++) {
-				out.writeObject(accountMap.get(i));
+				out.writeObject(accountMap.get(String.valueOf(i)));
 			}
 		} catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION
The accountMap object is a generic collection that maps String
arguments to Account objects. The argument for the call to
accountMap.get() is casted to a String for correctness.